### PR TITLE
add events to draw background and foreground

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,5 +83,7 @@ Game.prototype.draw = function(){
     this.context.fillStyle = this.backgroundColor;
   }
   this.context.fillRect(0, 0, this.width, this.height);
-  this.emit('draw', this.context)
+  this.emit('draw-background', this.context);
+  this.emit('draw', this.context);
+  this.emit('draw-foreground', this.context);
 };


### PR DESCRIPTION
Adds event `'draw-background'` after filling background colour, but before emitting draw to entities, and `'draw-foreground'` after emitting draw to entities.
